### PR TITLE
Small fixes from initial implementation

### DIFF
--- a/algolia.php
+++ b/algolia.php
@@ -49,7 +49,7 @@ add_action(
         if (defined('WP_CLI') && WP_CLI) {
             require_once 'inc/Commands.php';
             $commands = new \WpAlgolia\Commands($indexRepository);
-            WP_CLI::add_command('algolia', $commands);
+            \WP_CLI::add_command('algolia', $commands);
         }
 
     }

--- a/inc/MyCompany/PostsIndexSettingsFactory.php
+++ b/inc/MyCompany/PostsIndexSettingsFactory.php
@@ -22,7 +22,7 @@ class PostsIndexSettingsFactory
             array(
                 'searchableAttributes' => array(
                     'unordered(post_title)',
-                    'unordered(content)',
+                    'unordered(post_content)',
                 ),
                 'customRanking' => array(
                     'desc(post_date)',


### PR DESCRIPTION
Thanks for this great boilerplate! Here are a couple very minor suggested fixes from my initial use of this code.

- Add root namespace backslash to `WP_CLI`. Not necessary in this context but makes it consistent with other classes—and if you end up copying and pasting this code (likely) to a namespaced context it could help with a hard to troubleshoot WP-CLI error.

- Use correct `post_content` field name.