### PR TITLE
Don't push records on autosaves or revisions.

### DIFF
--- a/inc/MyCompany/PostChangeListener.php
+++ b/inc/MyCompany/PostChangeListener.php
@@ -37,6 +37,10 @@ class PostChangeListener
      */
     public function pushRecords($postId, $post)
     {
+        if (wp_is_post_autosave($post) || wp_get_post_revision($post)) {
+            return;
+        }
+
         if ($this->postType !== $post->post_type) {
             return;
         }


### PR DESCRIPTION
Without this check, autosaves and revisions will be pushed to Algolia index. Thought about making this configurable, but struggling to think of a use case where this would be desired.