### PR TITLE
Typo in function call to check revision status. 😞

### DIFF
--- a/inc/MyCompany/PostChangeListener.php
+++ b/inc/MyCompany/PostChangeListener.php
@@ -37,7 +37,7 @@ class PostChangeListener
      */
     public function pushRecords($postId, $post)
     {
-        if (wp_is_post_autosave($post) || wp_get_post_revision($post)) {
+        if (wp_is_post_autosave($post) || wp_is_post_revision($post)) {
             return;
         }
 


### PR DESCRIPTION
With apologies, I provided the incorrect function call in my last PR. This is an important fix since `wp_get_post_revision` returns a (truthy) post object.